### PR TITLE
Adds per-container-ip detection.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,39 +5,39 @@ import (
 )
 
 type Auth struct {
-	Enabled		bool
-	Username	string
-	Password	string
+	Enabled  bool
+	Username string
+	Password string
 }
 
 type SSL struct {
-	Enabled		bool
-	Verify		bool
-	Cert		string
-	CaCert		string
+	Enabled bool
+	Verify  bool
+	Cert    string
+	CaCert  string
 }
 
 type Config struct {
-	Refresh		time.Duration
-	RegistryAuth	*Auth
-	RegistryPort	string
-	RegistrySSL	*SSL
-	RegistryToken	string
-	Zk		string
-	LogLevel	string
+	Refresh       time.Duration
+	RegistryAuth  *Auth
+	RegistryPort  string
+	RegistrySSL   *SSL
+	RegistryToken string
+	Zk            string
+	LogLevel      string
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		Refresh:	time.Minute,
-		RegistryAuth:	&Auth{
+		Refresh: time.Minute,
+		RegistryAuth: &Auth{
 			Enabled: false,
 		},
-		RegistrySSL:	&SSL{
+		RegistrySSL: &SSL{
 			Enabled: false,
-			Verify: true,
+			Verify:  true,
 		},
-		RegistryToken:	"",
-		Zk:		"zk://127.0.0.1:2181/mesos",
+		RegistryToken: "",
+		Zk:            "zk://127.0.0.1:2181/mesos",
 	}
 }

--- a/config/flags.go
+++ b/config/flags.go
@@ -12,7 +12,7 @@ type AuthVar Auth
 func (a *AuthVar) Set(value string) error {
 	a.Enabled = true
 
-	if (strings.Contains(value, ":")) {
+	if strings.Contains(value, ":") {
 		split := strings.SplitN(value, ":", 2)
 		a.Username = split[0]
 		a.Password = split[1]

--- a/main.go
+++ b/main.go
@@ -28,9 +28,9 @@ func main() {
 	leader := mesos.New(c, consul.NewConsul(c))
 
 	ticker := time.NewTicker(c.Refresh)
-        leader.Refresh()
+	leader.Refresh()
 	for _ = range ticker.C {
-	        leader.Refresh()
+		leader.Refresh()
 	}
 }
 
@@ -43,17 +43,17 @@ func parseFlags(args []string) (*config.Config, error) {
 		fmt.Print(usage)
 	}
 
-	flags.BoolVar(&doHelp,			"help", false, "")
-	flags.StringVar(&c.LogLevel,		"log-level", "WARN", "")
-	flags.DurationVar(&c.Refresh,		"refresh", time.Minute, "")
-	flags.StringVar(&c.RegistryPort,	"registry-port", "8500", "")
-	flags.Var((*config.AuthVar)(c.RegistryAuth),	"registry-auth", "")
-	flags.BoolVar(&c.RegistrySSL.Enabled,	"registry-ssl", c.RegistrySSL.Enabled, "")
-	flags.BoolVar(&c.RegistrySSL.Verify,	"registry-ssl-verify", c.RegistrySSL.Verify, "")
-	flags.StringVar(&c.RegistrySSL.Cert,	"registry-ssl-cert", c.RegistrySSL.Cert, "")
-	flags.StringVar(&c.RegistrySSL.CaCert,	"registry-ssl-cacert", c.RegistrySSL.CaCert, "")
-	flags.StringVar(&c.RegistryToken,		"registry-token", c.RegistryToken, "")
-	flags.StringVar(&c.Zk,			"zk", "zk://127.0.0.1:2181/mesos", "")
+	flags.BoolVar(&doHelp, "help", false, "")
+	flags.StringVar(&c.LogLevel, "log-level", "WARN", "")
+	flags.DurationVar(&c.Refresh, "refresh", time.Minute, "")
+	flags.StringVar(&c.RegistryPort, "registry-port", "8500", "")
+	flags.Var((*config.AuthVar)(c.RegistryAuth), "registry-auth", "")
+	flags.BoolVar(&c.RegistrySSL.Enabled, "registry-ssl", c.RegistrySSL.Enabled, "")
+	flags.BoolVar(&c.RegistrySSL.Verify, "registry-ssl-verify", c.RegistrySSL.Verify, "")
+	flags.StringVar(&c.RegistrySSL.Cert, "registry-ssl-cert", c.RegistrySSL.Cert, "")
+	flags.StringVar(&c.RegistrySSL.CaCert, "registry-ssl-cacert", c.RegistrySSL.CaCert, "")
+	flags.StringVar(&c.RegistryToken, "registry-token", c.RegistryToken, "")
+	flags.StringVar(&c.Zk, "zk", "zk://127.0.0.1:2181/mesos", "")
 
 	if err := flags.Parse(args); err != nil {
 		return nil, err
@@ -64,16 +64,16 @@ func parseFlags(args []string) (*config.Config, error) {
 		return nil, fmt.Errorf("extra argument(s): %q", args)
 	}
 
-	if (doHelp) {
+	if doHelp {
 		flags.Usage()
 		os.Exit(0)
 	}
 
 	logging.Setup(&logging.Config{
-		Name:		"mesos-consul",
-		Level:		c.LogLevel,
-		Writer:		os.Stderr,
-		})
+		Name:   "mesos-consul",
+		Level:  c.LogLevel,
+		Writer: os.Stderr,
+	})
 
 	return c, nil
 }

--- a/mesos/types.go
+++ b/mesos/types.go
@@ -1,40 +1,52 @@
 package mesos
 
 type follower struct {
-	Id		string	`json:"id"`
-	Hostname	string	`json:"hostname"`
-	Pid		string	`json:"pid"`
+	Id       string `json:"id"`
+	Hostname string `json:"hostname"`
+	Pid      string `json:"pid"`
 }
 
 type Followers []follower
 
-type Resources struct {
-	Ports		string	`json:"ports"`
+type Label struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
-type Tasks []struct {
-	FrameworkId	string	`json:"framework_id"`
-	Id		string	`json:"id"`
-	Name		string	`json:"name"`
-	FollowerId	string	`json:"slave_id"`
-	State		string	`json:"state"`
-	Resources		`json:"resources"`
+type Resources struct {
+	Ports string `json:"ports"`
+}
+
+type Status struct {
+	Timestamp float64 `json:"timestamp"`
+	State     string  `json:"state"`
+	Labels    []Label `json:"labels,omitempty"`
+}
+
+type Task struct {
+	FrameworkId string   `json:"framework_id"`
+	Id          string   `json:"id"`
+	Name        string   `json:"name"`
+	FollowerId  string   `json:"slave_id"`
+	State       string   `json:"state"`
+	Statuses    []Status `json:"statuses"`
+	Resources   `json:"resources"`
 }
 
 type Frameworks []struct {
-	Tasks			`json:"tasks"`
-	Name		string	`json:"name"`
+	Tasks []Task `json:"tasks"`
+	Name  string `json:"name"`
 }
 
 type StateJSON struct {
-	Frameworks		`json:"frameworks"`
-	Followers		`json:"slaves"`
-	Leader		string	`json:"leader"`
+	Frameworks `json:"frameworks"`
+	Followers  `json:"slaves"`
+	Leader     string `json:"leader"`
 }
 
 type MesosHost struct {
-	host		string
-	port		string
-	isLeader	bool
-	isRegistered	bool
+	host         string
+	port         string
+	isLeader     bool
+	isRegistered bool
 }

--- a/mesos/zk.go
+++ b/mesos/zk.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (m *Mesos) zkDetector(zkURI string) {
-	if (zkURI == "") {
+	if zkURI == "" {
 		log.Fatal("[ERROR] Zookeeper address not provided")
 	}
 
@@ -91,11 +91,11 @@ func (m *Mesos) getMasters() []MesosHost {
 	ms := make([]MesosHost, len(*m.Masters))
 	for i, msp := range *m.Masters {
 		mh := MesosHost{
-			host:		msp.host,
-			port:		msp.port,
-			isLeader:	msp.isLeader,
+			host:     msp.host,
+			port:     msp.port,
+			isLeader: msp.isLeader,
 		}
-			
+
 		ms[i] = mh
 	}
 	return ms
@@ -111,7 +111,7 @@ func (m *Mesos) hostFromMasterInfo(mi *mesosproto.MasterInfo) MesosHost {
 			if err != nil {
 				ipstring = host
 			} else {
-				for _,i := range(ip) {
+				for _, i := range ip {
 					four := i.To4()
 					if four != nil {
 						ipstring = i.String()
@@ -134,11 +134,10 @@ func (m *Mesos) hostFromMasterInfo(mi *mesosproto.MasterInfo) MesosHost {
 	if len(ipstring) > 0 {
 		port = fmt.Sprint(mi.GetPort())
 	}
-		
 
 	return MesosHost{
-		host:		ipstring,
-		port:		port,
-		isLeader:	false,
+		host:     ipstring,
+		port:     port,
+		isLeader: false,
 	}
 }


### PR DESCRIPTION
Hi. This pull request adds per-container IP detection similar to the way provided by mesos-dns which is a necessary feature for such networking models as Calico.

Port number discovery is currently not functioning since no labels have yet been designated for service ports as have been for Container IP's.

Also applied `go fmt`.