### PR TITLE
Add tags for specific ports exposed in discovery section of state.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 mesos-consul
 build/
+.idea/


### PR DESCRIPTION
@ChrisAubuchon please take a look.

Before this PR `mesos-consul` didn't respect the `discovery` section of **state.json**, this one:
```json
                    "discovery": {
                        "ports": {
                            "ports": [
                                {
                                    "name": "CLIENT_PORT",
                                    "number": 4000
                                },
                                {
                                    "name": "TRANSPORT_PORT",
                                    "number": 4001
                                }
                            ]
                        },
                        "visibility": "EXTERNAL"
                    },
```

By now it **does** register there ports as separate **tags** for framework's service in `Consul`, they look like this:
```json
[
    {
        "Address": "10.10.10.12",
        "Node": "alpha-worker-004",
        "ServiceAddress": "10.10.10.12",
        "ServiceID": "mesos-consul:10.10.10.12:elasticsearch-executor:4000",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4000,
        "ServiceTags": null
    },
    {
        "Address": "10.10.10.12",
        "Node": "alpha-worker-004",
        "ServiceAddress": "10.10.10.12",
        "ServiceID": "mesos-consul:10.10.10.12:elasticsearch-executor:4001",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4001,
        "ServiceTags": null
    },
    {
        "Address": "10.10.10.2",
        "Node": "alpha-worker-005",
        "ServiceAddress": "10.10.10.2",
        "ServiceID": "mesos-consul:10.10.10.2:elasticsearch-executor:4000",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4000,
        "ServiceTags": null
    },
    {
        "Address": "10.10.10.2",
        "Node": "alpha-worker-005",
        "ServiceAddress": "10.10.10.2",
        "ServiceID": "mesos-consul:10.10.10.2:elasticsearch-executor:4001",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4001,
        "ServiceTags": null
    },
    {
        "Address": "10.10.10.13",
        "Node": "alpha-worker-007",
        "ServiceAddress": "10.10.10.13",
        "ServiceID": "mesos-consul:10.10.10.13:elasticsearch-executor:4000",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4000,
        "ServiceTags": null
    },
    {
        "Address": "10.10.10.13",
        "Node": "alpha-worker-007",
        "ServiceAddress": "10.10.10.13",
        "ServiceID": "mesos-consul:10.10.10.13:elasticsearch-executor:4001",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4001,
        "ServiceTags": null
    },
    {
        "Address": "10.10.10.12",
        "Node": "alpha-worker-004",
        "ServiceAddress": "10.10.10.12",
        "ServiceID": "mesos-consul:10.10.10.12:elasticsearch-executor:%!s(int=4000)",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4000,
        "ServiceTags": [
            "CLIENT_PORT"
        ]
    },
    {
        "Address": "10.10.10.12",
        "Node": "alpha-worker-004",
        "ServiceAddress": "10.10.10.12",
        "ServiceID": "mesos-consul:10.10.10.12:elasticsearch-executor:%!s(int=4001)",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4001,
        "ServiceTags": [
            "TRANSPORT_PORT"
        ]
    },
    {
        "Address": "10.10.10.2",
        "Node": "alpha-worker-005",
        "ServiceAddress": "10.10.10.2",
        "ServiceID": "mesos-consul:10.10.10.2:elasticsearch-executor:%!s(int=4000)",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4000,
        "ServiceTags": [
            "CLIENT_PORT"
        ]
    },
    {
        "Address": "10.10.10.2",
        "Node": "alpha-worker-005",
        "ServiceAddress": "10.10.10.2",
        "ServiceID": "mesos-consul:10.10.10.2:elasticsearch-executor:%!s(int=4001)",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4001,
        "ServiceTags": [
            "TRANSPORT_PORT"
        ]
    },
    {
        "Address": "10.10.10.13",
        "Node": "alpha-worker-007",
        "ServiceAddress": "10.10.10.13",
        "ServiceID": "mesos-consul:10.10.10.13:elasticsearch-executor:%!s(int=4000)",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4000,
        "ServiceTags": [
            "CLIENT_PORT"
        ]
    },
    {
        "Address": "10.10.10.13",
        "Node": "alpha-worker-007",
        "ServiceAddress": "10.10.10.13",
        "ServiceID": "mesos-consul:10.10.10.13:elasticsearch-executor:%!s(int=4001)",
        "ServiceName": "elasticsearch-executor",
        "ServicePort": 4001,
        "ServiceTags": [
            "TRANSPORT_PORT"
        ]
    }
]
```

And now we can query `Consul`'s DNS for SRV records successfully:
```bash
[17:18][alpha-worker-001][~] $ dig +short SRV client_port.elasticsearch-executor.service.consul
1 1 4000 alpha-worker-005.node.dc2.consul.
1 1 4000 alpha-worker-007.node.dc2.consul.
1 1 4000 alpha-worker-004.node.dc2.consul.
[17:19][alpha-worker-001][~] $ dig +short SRV transport_port.elasticsearch-executor.service.consul
1 1 4001 alpha-worker-007.node.dc2.consul.
1 1 4001 alpha-worker-005.node.dc2.consul.
1 1 4001 alpha-worker-004.node.dc2.consul.
```
