### PR TITLE
Providing service availability health checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mesos-consul
 
-Mesos to Consul bridge for service discovery. 
+Mesos to Consul bridge for service discovery.
 
 Mesos-consul automatically registers/deregisters services run as Mesos tasks.
 
@@ -44,7 +44,7 @@ Registrator is another tool that populates Consul (and other backends like etcd)
 
 ## Building
 ```
-docker build -t mesos-consul . 
+docker build -t mesos-consul .
 ```
 
 ## Running
@@ -72,7 +72,7 @@ Where `mesos-consul.json` is similar to (replacing the image with your image):
   "id": "mesos-consul",
   "instances": 1,
   "cpus": 0.1,
-  "mem": 256 
+  "mem": 256
 }
 
 
@@ -87,7 +87,12 @@ You can add options to authenticate via basic http or Consul token.
 
 |         Option        | Description |
 |-----------------------|-------------|
+| `version`             | Print mesos-consul version
 | `refresh`             | Time between refreshes of Mesos tasks
+| `mesos-ip-order`             | Comma separated list to control the order in which github.com/CiscoCloud/mesos-consul searches or the task IP address. Valid options are 'netinfo', 'mesos', 'docker' and 'host' (default netinfo,mesos,host)
+| `healthcheck`             | Enables a http endpoint for health checks. When this flag is enabled, serves health status on 127.0.0.1:24476
+| `healthcheck-ip`             | Health check service interface ip. Default 127.0.0.1
+| `healthcheck-port`             | Health check service port. Default 24476
 | `consul-auth`       | The basic authentication username (and optional password), separated by a colon.
 | `consul-ssl`        | Use HTTPS while talking to the registry.
 | `consul-ssl-verify` | Verify certificates when connecting via SSL.
@@ -101,7 +106,7 @@ You can add options to authenticate via basic http or Consul token.
 
 #### Leader, Master and Follower Nodes
 
-|    Role    | Registration 
+|    Role    | Registration
 |------------|--------------
 | `Leader`   | `leader.mesos.service.consul`, `master.mesos.service.consul`
 | `Master`   | `master.mesos.service.consul`
@@ -115,7 +120,7 @@ Tasks are registered as `task_name.service.consul`
 
 Tags can be added to consul by using labels in Mesos. If you are using Marathon you can add a label called `tags` to your service definition with a  comma-separated list of strings that will be registered in consul as tags.
 
-For example, in your marathon service definition: 
+For example, in your marathon service definition:
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ You can add options to authenticate via basic http or Consul token.
 | `refresh`             | Time between refreshes of Mesos tasks
 | `mesos-ip-order`             | Comma separated list to control the order in which github.com/CiscoCloud/mesos-consul searches or the task IP address. Valid options are 'netinfo', 'mesos', 'docker' and 'host' (default netinfo,mesos,host)
 | `healthcheck`             | Enables a http endpoint for health checks. When this flag is enabled, serves health status on 127.0.0.1:24476
-| `healthcheck-ip`             | Health check service interface ip. Default 127.0.0.1
-| `healthcheck-port`             | Health check service port. Default 24476
+| `healthcheck-ip`             | Health check service interface ip (default 127.0.0.1)
+| `healthcheck-port`             | Health check service port. (default 24476)
 | `consul-auth`       | The basic authentication username (and optional password), separated by a colon.
 | `consul-ssl`        | Use HTTPS while talking to the registry.
 | `consul-ssl-verify` | Verify certificates when connecting via SSL.
 | `consul-ssl-cert`   | Path to an SSL certificate to use to authenticate to the registry server
-| `consul-ssl-cacert` | Path to a CA certificate file, containing one or more CA certificates to use to valid the reigstry server certificate
+| `consul-ssl-cacert` | Path to a CA certificate file, containing one or more CA certificates to use to valid the registry server certificate
 | `consul-token`      | The registry ACL token
 | `zk`*                 | Location of the Mesos path in Zookeeper. The default value is zk://127.0.0.1:2181/mesos
 

--- a/config/config.go
+++ b/config/config.go
@@ -5,16 +5,22 @@ import (
 )
 
 type Config struct {
-	Refresh      time.Duration
-	Zk           string
-	LogLevel     string
-	MesosIpOrder string
+	Refresh          time.Duration
+	Zk               string
+	LogLevel         string
+	MesosIpOrder     string
+	Healthcheck      bool
+	HealthcheckIp    string
+	HealthcheckPort  string
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		Refresh:      time.Minute,
-		Zk:           "zk://127.0.0.1:2181/mesos",
-		MesosIpOrder: "netinfo,mesos,host",
+		Refresh:        time.Minute,
+		Zk:             "zk://127.0.0.1:2181/mesos",
+		MesosIpOrder:   "netinfo,mesos,host",
+		Healthcheck:    false,
+		HealthcheckIp:  "127.0.0.1",
+		HealthcheckPort: "24476",
 	}
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"time"
+  "net/http"
 
 	"github.com/CiscoCloud/mesos-consul/config"
 	"github.com/CiscoCloud/mesos-consul/consul"
@@ -23,6 +24,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if c.Healthcheck {
+		go StartHealthcheckService(c)
+	}
+
 	log.Info("Using zookeeper: ", c.Zk)
 	leader := mesos.New(c)
 
@@ -33,20 +38,34 @@ func main() {
 	}
 }
 
+func StartHealthcheckService(c *config.Config) {
+	http.HandleFunc("/health", HealthHandler)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%s", c.HealthcheckIp, c.HealthcheckPort), nil))
+}
+
+func HealthHandler(w http.ResponseWriter, r *http.Request) {
+  fmt.Fprintln(w, "OK")
+}
+
 func parseFlags(args []string) (*config.Config, error) {
 	var doHelp bool
+	var doVersion bool
 	var c = config.DefaultConfig()
 
-	flags := flag.NewFlagSet("mesos-consul", flag.ContinueOnError)
+	flags := flag.NewFlagSet("github.com/CiscoCloud/mesos-consul", flag.ContinueOnError)
 	flags.Usage = func() {
 		fmt.Println(Help())
 	}
 
 	flags.BoolVar(&doHelp, "help", false, "")
+	flags.BoolVar(&doVersion, "version", false, "")
 	flags.StringVar(&c.LogLevel, "log-level", "WARN", "")
 	flags.DurationVar(&c.Refresh, "refresh", time.Minute, "")
 	flags.StringVar(&c.Zk, "zk", "zk://127.0.0.1:2181/mesos", "")
 	flags.StringVar(&c.MesosIpOrder, "mesos-ip-order", "netinfo,mesos,host", "")
+	flags.BoolVar(&c.Healthcheck, "healthcheck", false, "")
+	flags.StringVar(&c.HealthcheckIp, "healthcheck-ip", "127.0.0.1", "")
+	flags.StringVar(&c.HealthcheckPort, "healthcheck-port", "24476", "")
 
 	consul.AddCmdFlags(flags)
 
@@ -59,6 +78,10 @@ func parseFlags(args []string) (*config.Config, error) {
 		return nil, fmt.Errorf("extra argument(s): %q", args)
 	}
 
+	if doVersion {
+		fmt.Printf("%s v%s\n", Name, Version)
+		os.Exit(0)
+	}
 	if doHelp {
 		flags.Usage()
 		os.Exit(0)
@@ -77,20 +100,22 @@ func parseFlags(args []string) (*config.Config, error) {
 
 func Help() string {
 	helpText := `
-Usage: mesos-consul [options]
+Usage: github.com/CiscoCloud/mesos-consul [options]
 
 Options:
 
+  --version 			Print mesos-consul version
   --log-level=<log_level>	Set the Logging level to one of [ "DEBUG", "INFO", "WARN", "ERROR" ]
 				(default "WARN")
-  --refresh=<time>		Set the Mesos refresh rate
-				(default 1m)
-  --zk=<address>		Zookeeper path to Mesos
-				(default zk://127.0.0.1:2181/mesos)
-  --mesos-ip-order=		Comma separated list to control the order in
-				which mesos-consul searches for the task IP
-				address. Valid options are 'netinfo', 'mesos',
-				'docker' and 'host'
+  --refresh=<time>		Set the Mesos refresh rate (default 1m)
+  --zk=<address>		Zookeeper path to Mesos (default zk://127.0.0.1:2181/mesos)
+  --healthcheck 		Enables a http endpoint for health checks. When this
+				flag is enabled, serves a service health status on 127.0.0.1:24476 (default not enabled)
+  --healthcheck-ip=<ip> 	Health check interface ip (default 127.0.0.1)
+  --healthcheck-port=<port>	Health check service port (default 24476)
+  --mesos-ip-order		Comma separated list to control the order in
+				which github.com/CiscoCloud/mesos-consul searches for the task IP
+				address. Valid options are 'netinfo', 'mesos', 'docker' and 'host'
 				(default netinfo,mesos,host)
 ` + consul.Help()
 

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func parseFlags(args []string) (*config.Config, error) {
 	var doVersion bool
 	var c = config.DefaultConfig()
 
-	flags := flag.NewFlagSet("github.com/CiscoCloud/mesos-consul", flag.ContinueOnError)
+	flags := flag.NewFlagSet("mesos-consul", flag.ContinueOnError)
 	flags.Usage = func() {
 		fmt.Println(Help())
 	}
@@ -100,7 +100,7 @@ func parseFlags(args []string) (*config.Config, error) {
 
 func Help() string {
 	helpText := `
-Usage: github.com/CiscoCloud/mesos-consul [options]
+Usage: mesos-consul [options]
 
 Options:
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 	"time"
-  "net/http"
+	"net/http"
 
 	"github.com/CiscoCloud/mesos-consul/config"
 	"github.com/CiscoCloud/mesos-consul/consul"


### PR DESCRIPTION
When deploying this service over Mesos + Marathon using a docker container, there is no way for Marathon to know if the service is up and running at any given time. [See http://i.imgur.com/lGnVqZm.png].
In this PR, an optional feature has been added that allows health checks over an specified interface ip and port. Documentation have been updated accordingly.

TODO:
- Probably a little bit of a stretch, but If the health check web service dies, the parent process should be notified. 