### PR TITLE
Allow option to specify consul agent address

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ Where `mesos-consul.json` is similar to (replacing the image with your image):
 {
   "args": [
     "--zk=zk://zookeeper.service.consul:2181/mesos"
-  ],  
+  ],
   "container": {
     "type": "DOCKER",
     "docker": {
       "network": "BRIDGE",
       "image": "{{ mesos_consul_image }}:{{ mesos_consul_image_tag }}"
-    }   
-  },  
+    }
+  },
   "id": "mesos-consul",
   "instances": 1,
   "cpus": 0.1,
@@ -93,6 +93,8 @@ You can add options to authenticate via basic http or Consul token.
 | `healthcheck`             | Enables a http endpoint for health checks. When this flag is enabled, serves health status on 127.0.0.1:24476
 | `healthcheck-ip`             | Health check service interface ip (default 127.0.0.1)
 | `healthcheck-port`             | Health check service port. (default 24476)
+| `consul-address`    | The Consul agent API address. If empty, will use the service's agent's address. (default "")
+| `consul-port`       | The Consul agent API port. (default 8500)
 | `consul-auth`       | The basic authentication username (and optional password), separated by a colon.
 | `consul-ssl`        | Use HTTPS while talking to the registry.
 | `consul-ssl-verify` | Verify certificates when connecting via SSL.

--- a/consul/config.go
+++ b/consul/config.go
@@ -10,6 +10,7 @@ import (
 type consulConfig struct {
 	enabled    bool
 	auth       auth
+	address    string
 	port       string
 	sslEnabled bool
 	sslVerify  bool
@@ -22,6 +23,7 @@ var config consulConfig
 
 func AddCmdFlags(f *flag.FlagSet) {
 	f.BoolVar(&config.enabled, "consul", false, "")
+	f.StringVar(&config.address, "consul-address", "", "")
 	f.StringVar(&config.port, "consul-port", "8500", "")
 	f.Var((*authVar)(&config.auth), "consul-auth", "")
 	f.BoolVar(&config.sslEnabled, "consul-ssl", false, "")
@@ -36,6 +38,8 @@ func Help() string {
 Consul Options:
 
   --consul			Use Consul backend
+  --consul-address Consul agent API address. If empty, will use the service's agent's address.
+				(default: "")
   --consul-port			Consul agent API port
 				(default: 8500)
   --consul-auth			The basic authentication username (and optional password),


### PR DESCRIPTION
Provides an option to specify the consul agent's IP address to use when registering services.

By using this option to specify consul agent at 127.0.0.1 (or some other consul server), we can use an existing consul cluster without forcing non-server consul agents to listen on 0.0.0.0.

See: https://github.com/CiscoCloud/mesos-consul/issues/17