### PR TITLE
Add multi-failure check before removing register

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ You can add options to authenticate via basic http or Consul token.
 | `consul-ssl-cert`   | Path to an SSL certificate to use to authenticate to the registry server
 | `consul-ssl-cacert` | Path to a CA certificate file, containing one or more CA certificates to use to valid the registry server certificate
 | `consul-token`      | The registry ACL token
+| `heartbeats-before-remove` | Number of times that registration needs to fail before removing task from Consul. (default: 1)
 | `zk`*                 | Location of the Mesos path in Zookeeper. The default value is zk://127.0.0.1:2181/mesos
 
 

--- a/consul/config.go
+++ b/consul/config.go
@@ -8,14 +8,15 @@ import (
 )
 
 type consulConfig struct {
-	enabled    bool
-	auth       auth
-	port       string
-	sslEnabled bool
-	sslVerify  bool
-	sslCert    string
-	sslCaCert  string
-	token      string
+	enabled                bool
+	auth                   auth
+	port                   string
+	sslEnabled             bool
+	sslVerify              bool
+	sslCert                string
+	sslCaCert              string
+	token                  string
+	heartbeatsBeforeRemove int
 }
 
 var config consulConfig
@@ -29,6 +30,7 @@ func AddCmdFlags(f *flag.FlagSet) {
 	f.StringVar(&config.sslCert, "consul-ssl-cert", "", "")
 	f.StringVar(&config.sslCaCert, "consul-ssl-cacert", "", "")
 	f.StringVar(&config.token, "consul-token", "", "")
+	f.IntVar(&config.heartbeatsBeforeRemove, "heartbeats-before-remove", 1, "")
 }
 
 func Help() string {
@@ -54,6 +56,9 @@ Consul Options:
 				(default: not set)
   --consul-token		The Consul ACL token
 				(default: not set)
+  --heartbeats-before-remove	Number of times that registration needs to fail
+				before removing task from Consul
+				(default: 1)
 
 `
 


### PR DESCRIPTION
Adding a flag to be able to specify a number of failed checks before
mesos-consul removes the task from consul.

The motivation behind this change is because we had observed that
mesos-consul was removing running tasks from consul when the leader
mesos-master was down during the poll for running tasks. This would lead
to our load balancer getting reconfigured to have no services for a
significant period of time. The idea behind this solution is to
configure the number of times mesos-consul should tolerate not finding
the registered task in the mesos-master leader state before
de-registering it from Consul.