### PR TITLE
Added all Mesos labels as Consul service tags in the form key=value. …

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -119,6 +119,10 @@ func (c *Consul) Register(service *registry.Service) {
 		s.Tags = service.Tags
 	}
 
+	for k, v := range service.Labels {
+		s.Tags = append(s.Tags, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	err := c.agents[service.Agent].Agent().ServiceRegister(s)
 	if err != nil {
 		log.Warnf("Unable to register %s: %s", s.ID, err.Error())

--- a/mesos/register.go
+++ b/mesos/register.go
@@ -30,7 +30,6 @@ func (m *Mesos) RegisterHosts(s state.State) {
 
 	m.Agents = make(map[string]string)
 
-
 	// Register slaves
 	for _, f := range s.Slaves {
 		agent := toIP(f.PID.Host)
@@ -137,6 +136,11 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 		tags = []string{}
 	}
 
+	labels := make(map[string]string)
+	for _, v := range t.Labels {
+		labels[v.Key] = v.Value
+	}
+
 	for key := range t.DiscoveryInfo.Ports.DiscoveryPorts {
 		discoveryPort := state.DiscoveryPort(t.DiscoveryInfo.Ports.DiscoveryPorts[key])
 		serviceName := discoveryPort.Name
@@ -168,6 +172,7 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 				Name:    tname,
 				Port:    toPort(port),
 				Address: address,
+				Labels:  labels,
 				Tags:    tags,
 				Check: GetCheck(t, &CheckVar{
 					Host: toIP(address),
@@ -181,6 +186,7 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 			ID:      fmt.Sprintf("mesos-consul:%s-%s", agent, tname),
 			Name:    tname,
 			Address: address,
+			Labels:  labels,
 			Tags:    tags,
 			Check: GetCheck(t, &CheckVar{
 				Host: toIP(address),

--- a/registry/structs.go
+++ b/registry/structs.go
@@ -12,6 +12,7 @@ type Service struct {
 	Name    string
 	Port    int
 	Address string
+	Labels  map[string]string
 	Tags    []string
 	Check   *Check
 	Agent   string
@@ -24,7 +25,7 @@ type Registry interface {
 	CacheLookup(string) *Service
 	CacheMark(string)
 
-	Register(*Service) 
+	Register(*Service)
 	Deregister() error
 }
 


### PR DESCRIPTION
As of now, mesos-consul only registered a task's special Mesos label "tags" in Consul.

This PR broadens this feature to all available Mesos labels. Since Consul service tags are a simple array instead of a map, they're all mapped with the format 'key=value'.