### PR TITLE
Fix deregistration

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -138,7 +138,7 @@ func (c *Consul) Deregister() error {
 			c.CacheProcessDeregister(s)
 		} else {
 			log.Infof("Deregistering %s", s)
-			err = c.deregister(b.agent, b.service)
+			err := c.deregister(b.agent, b.service)
 			if err != nil {
 				// Deregistration often fails for valid reasons,
 				// most commonly that the host is down.

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -138,11 +138,16 @@ func (c *Consul) Deregister() error {
 			c.CacheProcessDeregister(s)
 		} else {
 			log.Infof("Deregistering %s", s)
-			err := c.deregister(b.agent, b.service)
+			err = c.deregister(b.agent, b.service)
 			if err != nil {
-				return err
+				// Deregistration often fails for valid reasons,
+				// most commonly that the host is down.
+				// Log the error and continue.
+				log.Info("Deregistration error ", err)
+			} else {
+				delete(serviceCache, s)
 			}
-			delete(serviceCache, s)
+
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug in deregistration, where the process aborts if a single deregistration fails.  This happens most commonly if a host is down, and means that any deregistrations after those on the downed host will not be performed.

This PR changes that behaviour so that a message will be thrown if a deregistration request fails (at info level) but degregistration will continue.