### PR TITLE
Add ability to tag mesos leader with custom tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ To build it:
 | `service-tags=<tag>,...` | Comma delimited list of tags to register the Mesos hosts. Mesos hosts will be registered as (leader|master|follower).<tag>.<service>.service.consul
 | `service-id-prefix=<prefix>` | Prefix to use for consul service ids registered by mesos-consul. (default: mesos-consul)
 | `task-tag=<pattern:tag>` | Tag tasks matching pattern with given tag. Can be specified multitple times
+| `leader-tags=<tag>,...` | Comma delimited list of tags to register the Mesos leader.
 | `zk`\*                 | Location of the Mesos path in Zookeeper. The default value is zk://127.0.0.1:2181/mesos
 | `log-level`            | Level that mesos-consul should log at. Options are [ "DEBUG", "INFO", "WARN", "ERROR" ]. Default is WARN. |
 | `group-separator`      | Choose the group separator. Will replace _ in task names (default is empty)

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Separator       string
 
 	// Mesos service name and tags
+	LeaderTags      string
 	ServiceName     string
 	ServiceTags     string
 	ServiceIdPrefix string
@@ -41,6 +42,7 @@ func DefaultConfig() *Config {
 		Separator:       "",
 		ServiceName:     "mesos",
 		ServiceTags:     "",
+		LeaderTags:      "",
 		ServiceIdPrefix: "mesos-consul",
 	}
 }

--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func parseFlags(args []string) (*config.Config, error) {
 	flags.StringVar(&c.ServiceName, "service-name", "mesos", "")
 	flags.StringVar(&c.ServiceTags, "service-tags", "", "")
 	flags.StringVar(&c.ServiceIdPrefix, "service-id-prefix", "mesos-consul", "")
+	flags.StringVar(&c.LeaderTags, "leader-tags", "", "")
 
 	consul.AddCmdFlags(flags)
 
@@ -158,6 +159,7 @@ Options:
 				Can be specified multiple times
   --service-name=<name>		Service name of the Mesos hosts. (default: mesos)
   --service-tags=<tag>,...	Comma delimited list of tags to add to the mesos hosts
+  --leader-tags=<tag>,...	Comma delimited list of tags to add to the mesos leader
 				Hosts are registered as
 				(leader|master|follower).<tag>.mesos.service.conul
 ` + consul.Help()

--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -45,6 +45,7 @@ type Mesos struct {
 	ServiceName     string
 	ServiceTags     []string
 	ServiceIdPrefix string
+	LeaderTags      []string
 }
 
 func New(c *config.Config) *Mesos {
@@ -89,6 +90,9 @@ func New(c *config.Config) *Mesos {
 	}
 
 	m.ServiceIdPrefix = c.ServiceIdPrefix
+	if c.LeaderTags != "" {
+		m.LeaderTags = strings.Split(c.LeaderTags, ",")
+	}
 
 	return m
 }

--- a/mesos/register.go
+++ b/mesos/register.go
@@ -57,7 +57,9 @@ func (m *Mesos) RegisterHosts(s state.State) {
 		var tags []string
 
 		if ma.IsLeader {
-			tags = m.agentTags("leader", "master")
+			default_tags := m.agentTags("leader", "master")
+			custom_tags := m.LeaderTags
+			tags = append(default_tags, custom_tags...)
 		} else {
 			tags = m.agentTags("master")
 		}


### PR DESCRIPTION
We use a generic consul tag to expose services through HAProxy via consul-template. Because mesos doesn't forward requests to the actual leader, we need a way of targeting the leader specifically with this tag.
This adds  a `--leader-tags` attribute that will allow the user to tag leader with custom tags.
