### PR TITLE
Replace _ from mesos task name by -

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ You can add options to authenticate via basic http or Consul token.
 | `whitelist`         | Only register services matching the provided regex. Can be specified multitple time
 | `service-name=<name>`      | Service name of the Mesos hosts
 | `service-tags=<tag>,...` | Comma delimited list of tags to register the Mesos hosts. Mesos hosts will be registered as (leader|master|follower).<tag>.<service>.service.consul
-| `zk`*                 | Location of the Mesos path in Zookeeper. The default value is zk://127.0.0.1:2181/mesos
+| `zk`\*                 | Location of the Mesos path in Zookeeper. The default value is zk://127.0.0.1:2181/mesos
+| `group-separator`      | Choose the group separator. Will replace _ in task names (default is empty)
 
 
 ### Consul Registration

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	HealthcheckIp   string
 	HealthcheckPort string
 	WhiteList       []string
+	Separator       string
 
 	// Mesos service name and tags
 	ServiceName	string
@@ -28,6 +29,7 @@ func DefaultConfig() *Config {
 		HealthcheckIp:   "127.0.0.1",
 		HealthcheckPort: "24476",
 		WhiteList:       []string{},
+		Separator:       "",
 		ServiceName:     "mesos",
 		ServiceTags:     "",
 	}

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func parseFlags(args []string) (*config.Config, error) {
 	flags.StringVar(&c.LogLevel, "log-level", "WARN", "")
 	flags.DurationVar(&c.Refresh, "refresh", time.Minute, "")
 	flags.StringVar(&c.Zk, "zk", "zk://127.0.0.1:2181/mesos", "")
+	flags.StringVar(&c.Separator, "group-separator", "", "")
 	flags.StringVar(&c.MesosIpOrder, "mesos-ip-order", "netinfo,mesos,host", "")
 	flags.BoolVar(&c.Healthcheck, "healthcheck", false, "")
 	flags.StringVar(&c.HealthcheckIp, "healthcheck-ip", "127.0.0.1", "")
@@ -115,6 +116,7 @@ Options:
 				(default "WARN")
   --refresh=<time>		Set the Mesos refresh rate (default 1m)
   --zk=<address>		Zookeeper path to Mesos (default zk://127.0.0.1:2181/mesos)
+  --group-separator=<separator> Choose the group separator. Will replace _ in task names (default is empty)
   --healthcheck 		Enables a http endpoint for health checks. When this
 				flag is enabled, serves a service health status on 127.0.0.1:24476 (default not enabled)
   --healthcheck-ip=<ip> 	Health check interface ip (default 127.0.0.1)

--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -38,6 +38,8 @@ type Mesos struct {
 	WhiteList string
 	whitelistRegex *regexp.Regexp
 
+	Separator string
+
 	ServiceName string
 	ServiceTags []string
 }
@@ -48,6 +50,7 @@ func New(c *config.Config) *Mesos {
 	if c.Zk == "" {
 		return nil
 	}
+	m.Separator = c.Separator
 
 	if len(c.WhiteList) > 0 {
 		m.WhiteList = strings.Join(c.WhiteList, "|")
@@ -64,7 +67,7 @@ func New(c *config.Config) *Mesos {
 		m.whitelistRegex = nil
 	}
 
-	m.ServiceName = cleanName(c.ServiceName)
+	m.ServiceName = cleanName(c.ServiceName, c.Separator)
 
 	m.Registry = consul.New()
 

--- a/mesos/register.go
+++ b/mesos/register.go
@@ -119,7 +119,7 @@ func (m *Mesos) registerHost(s *registry.Service) {
 func (m *Mesos) registerTask(t *state.Task, agent string) {
 	var tags []string
 
-	tname := cleanName(t.Name)
+	tname := cleanName(t.Name, m.Separator)
 	if m.whitelistRegex != nil {
 		if !m.whitelistRegex.MatchString(tname) {
 			log.WithField("task", tname).Debug("Task not on whitelist")

--- a/mesos/util.go
+++ b/mesos/util.go
@@ -9,7 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func cleanName(name string) string {
+func cleanName(name string, separator string) string {
 	reg, err := regexp.Compile("[^\\w-]")
 	if err != nil {
 		log.Warn(err)
@@ -18,7 +18,7 @@ func cleanName(name string) string {
 
 	s := reg.ReplaceAllString(name, "-")
 
-	return strings.ToLower(strings.Replace(s, "_", "-", -1))
+	return strings.ToLower(strings.Replace(s, "_", separator, -1))
 }
 
 func leaderIP(leader string) string {

--- a/mesos/util.go
+++ b/mesos/util.go
@@ -18,7 +18,7 @@ func cleanName(name string) string {
 
 	s := reg.ReplaceAllString(name, "-")
 
-	return strings.ToLower(strings.Replace(s, "_", "", -1))
+	return strings.ToLower(strings.Replace(s, "_", "-", -1))
 }
 
 func leaderIP(leader string) string {


### PR DESCRIPTION
Previously underscores where removed when creating the service name.
This usually does not correspond to the intent of the user since he set
a separator in the task name.

In the specific case of marathon, the folder separator is converted to
underscore when creating a mesos task.

Users in marathon sets: /mygroup/mysubgroup/myapp

Tasks name is mesos are: mygroup_mysubgroup_myapp.[guid]

Before this patch, consul service names were mygroupmysubgroupmyapp
After this patch, consul service names are mygroup-mysubgroup-myapp.

Fixes #63