### PR TITLE
add blacklist option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ You can add options to authenticate via basic http or Consul token.
 | `consul-token`      | The registry ACL token
 | `heartbeats-before-remove` | Number of times that registration needs to fail before removing task from Consul. (default: 1)
 | `whitelist`         | Only register services matching the provided regex. Can be specified multitple time
+| `blacklist`         | Does not register services matching the provided regex. Can be specified multitple time
 | `service-name=<name>`      | Service name of the Mesos hosts
 | `service-tags=<tag>,...` | Comma delimited list of tags to register the Mesos hosts. Mesos hosts will be registered as (leader|master|follower).<tag>.<service>.service.consul
 | `zk`\*                 | Location of the Mesos path in Zookeeper. The default value is zk://127.0.0.1:2181/mesos

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	HealthcheckIp   string
 	HealthcheckPort string
 	WhiteList       []string
+	BlackList       []string
 	Separator       string
 
 	// Mesos service name and tags
@@ -29,6 +30,7 @@ func DefaultConfig() *Config {
 		HealthcheckIp:   "127.0.0.1",
 		HealthcheckPort: "24476",
 		WhiteList:       []string{},
+		BlackList:       []string{},
 		Separator:       "",
 		ServiceName:     "mesos",
 		ServiceTags:     "",

--- a/main.go
+++ b/main.go
@@ -71,6 +71,10 @@ func parseFlags(args []string) (*config.Config, error) {
 		c.WhiteList = append(c.WhiteList, s)
 		return nil
 	}), "whitelist", "")
+	flags.Var((funcVar)(func(s string) error {
+		c.BlackList = append(c.BlackList, s)
+		return nil
+	}), "blacklist", "")
 	flags.StringVar(&c.ServiceName, "service-name", "mesos", "")
 	flags.StringVar(&c.ServiceTags, "service-tags", "", "")
 
@@ -128,6 +132,8 @@ Options:
   --heartbeats-before-remove	Number of times that registration needs to fail before removing
 				task from Consul. (default: 1)
   --whitelist=<regex>		Only register services matching the provided regex. 
+				Can be specified multiple times
+  --blacklist=<regex>		Only register services matching the provided regex. 
 				Can be specified multiple times
   --service-name=<name>		Service name of the Mesos hosts. (default: mesos)
   --service-tags=<tag>,...	Comma delimited list of tags to add to the mesos hosts

--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -37,6 +37,8 @@ type Mesos struct {
 	IpOrder        []string
 	WhiteList      string
 	whitelistRegex *regexp.Regexp
+	BlackList      string
+	blacklistRegex *regexp.Regexp
 
 	Separator string
 
@@ -65,6 +67,21 @@ func New(c *config.Config) *Mesos {
 		m.whitelistRegex = re
 	} else {
 		m.whitelistRegex = nil
+	}
+
+	if len(c.BlackList) > 0 {
+		m.BlackList = strings.Join(c.BlackList, "|")
+		log.WithField("blacklist", m.BlackList).Debug("Using blacklist regex")
+		re, err := regexp.Compile(m.BlackList)
+		if err != nil {
+			// For now, exit if the regex fails to compile. If we read regexes from Consul
+			// maybe we emit a warning and use the old regex
+			//
+			log.WithField("blacklist", m.BlackList).Fatal("BlackList regex failed to compile")
+		}
+		m.blacklistRegex = re
+	} else {
+		m.blacklistRegex = nil
 	}
 
 	m.ServiceName = cleanName(c.ServiceName, c.Separator)

--- a/mesos/register.go
+++ b/mesos/register.go
@@ -129,7 +129,7 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 	if m.blacklistRegex != nil {
 		if m.blacklistRegex.MatchString(tname) {
 			log.WithField("task", tname).Debug("Task on blacklist")
-			// No match
+			// Match
 			return
 		}
 	}

--- a/mesos/register.go
+++ b/mesos/register.go
@@ -126,6 +126,13 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 			return
 		}
 	}
+	if m.blacklistRegex != nil {
+		if m.blacklistRegex.MatchString(tname) {
+			log.WithField("task", tname).Debug("Task on blacklist")
+			// No match
+			return
+		}
+	}
 
 	address := t.IP(m.IpOrder...)
 


### PR DESCRIPTION
We had the same issue as was originally reported in https://github.com/CiscoCloud/mesos-consul/issues/45 with the request for a whitelisting feature (spark tasks), however, in our case a blacklist was more appropriate since we want mesos-consul to register the majority of tasks, and filter out only a few of them.

While it's possible to construct a "negative regex" and use that in the whitelist argument, it's clunky and not something regexes are particularly good at. A blacklist option is cleaner for this.

This pull request provides a blacklist option that is essentially the same as the whitelist implementation, but with opposite logic.