### PR TITLE
implement task-tag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ You can add options to authenticate via basic http or Consul token.
 | `blacklist`         | Does not register services matching the provided regex. Can be specified multitple time
 | `service-name=<name>`      | Service name of the Mesos hosts
 | `service-tags=<tag>,...` | Comma delimited list of tags to register the Mesos hosts. Mesos hosts will be registered as (leader|master|follower).<tag>.<service>.service.consul
+| `task-tag=<pattern:tag>` | Tag tasks matching pattern with given tag. Can be specified multitple times
 | `zk`\*                 | Location of the Mesos path in Zookeeper. The default value is zk://127.0.0.1:2181/mesos
 | `group-separator`      | Choose the group separator. Will replace _ in task names (default is empty)
 

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	HealthcheckPort string
 	WhiteList       []string
 	BlackList       []string
+	TaskTag         []string
 	Separator       string
 
 	// Mesos service name and tags
@@ -31,6 +32,7 @@ func DefaultConfig() *Config {
 		HealthcheckPort: "24476",
 		WhiteList:       []string{},
 		BlackList:       []string{},
+		TaskTag:         []string{},
 		Separator:       "",
 		ServiceName:     "mesos",
 		ServiceTags:     "",

--- a/main.go
+++ b/main.go
@@ -75,6 +75,10 @@ func parseFlags(args []string) (*config.Config, error) {
 		c.BlackList = append(c.BlackList, s)
 		return nil
 	}), "blacklist", "")
+	flags.Var((funcVar)(func(s string) error {
+		c.TaskTag = append(c.TaskTag, s)
+		return nil
+	}), "task-tag", "")
 	flags.StringVar(&c.ServiceName, "service-name", "mesos", "")
 	flags.StringVar(&c.ServiceTags, "service-tags", "", "")
 
@@ -134,6 +138,8 @@ Options:
   --whitelist=<regex>		Only register services matching the provided regex. 
 				Can be specified multiple times
   --blacklist=<regex>		Only register services matching the provided regex. 
+				Can be specified multiple times
+  --task-tag=<pattern:tag>	Tag tasks whose name contains 'pattern' substring (case-insensitive) with given tag.
 				Can be specified multiple times
   --service-name=<name>		Service name of the Mesos hosts. (default: mesos)
   --service-tags=<tag>,...	Comma delimited list of tags to add to the mesos hosts

--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -39,6 +39,7 @@ type Mesos struct {
 	whitelistRegex *regexp.Regexp
 	BlackList      string
 	blacklistRegex *regexp.Regexp
+	taskTag        map[string]string
 
 	Separator string
 
@@ -82,6 +83,17 @@ func New(c *config.Config) *Mesos {
 		m.blacklistRegex = re
 	} else {
 		m.blacklistRegex = nil
+	}
+
+	m.taskTag = make(map[string]string)
+	for _, tt := range c.TaskTag {
+		parts := strings.Split(tt, ":")
+		if len(parts) == 2 {
+			log.WithField("task-tag", c.TaskTag).Debug("Using task-tag pattern")
+			m.taskTag[strings.ToLower(parts[0])] = parts[1]
+		} else {
+			log.WithField("task-tag", c.TaskTag).Fatal("task-tag pattern invalid, must include 1 colon separator")
+		}
 	}
 
 	m.ServiceName = cleanName(c.ServiceName, c.Separator)

--- a/mesos/register.go
+++ b/mesos/register.go
@@ -143,6 +143,13 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 		tags = []string{}
 	}
 
+	for pattern, tag := range m.taskTag {
+		if strings.Contains(strings.ToLower(tname), pattern) {
+			log.WithField("task-tag", tname).Debug("Task matches pattern for tag")
+			tags = append(tags, tag)
+		}
+	}
+
 	for key := range t.DiscoveryInfo.Ports.DiscoveryPorts {
 		discoveryPort := state.DiscoveryPort(t.DiscoveryInfo.Ports.DiscoveryPorts[key])
 		serviceName := discoveryPort.Name


### PR DESCRIPTION
This pull request provides a command-line option that allows us to specify a pattern and a tag. The option can be provided more than once. Tasks whose names contain the pattern (case-insensitive) will have their services tagged with the given tag. This is helpful if a mesos framework does not provide an easy way to pass in labels for tasks. For example, with spark, we can do something like this:

`--task-tag=driver-for-spark:prometheus`

then we can use the `prometheus` service tag in consul to perform other service discovery.