### PR TITLE
Preserve task tags when registering with discovery info

### DIFF
--- a/mesos/register.go
+++ b/mesos/register.go
@@ -143,7 +143,7 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 				Name:    tname,
 				Port:    toPort(servicePort),
 				Address: address,
-				Tags:    []string{serviceName},
+				Tags:    append(tags, serviceName),
 				Check: GetCheck(t, &CheckVar{
 					Host: toIP(address),
 					Port: servicePort,


### PR DESCRIPTION
Tags have been getting lost when registering tasks that also include discovery info.

### Before-and-after example

- Framework: [ElasticSearch](https://github.com/mesos/elasticsearch)
- Executor: a Task named "elasticsearch" with a Mesos label `tags=test`

Before the change (with some fields omitted)
```
$ curl -s consul:8500/v1/catalog/service/elasticsearch | jq .
[{
    "Node": "mesos-follower-1",
    "ServiceName": "elasticsearch",
    "ServiceTags": [
      "CLIENT_PORT"
    ],
    "ServicePort": 9200
  }, {
    "Node": "mesos-follower-1",
    "ServiceName": "elasticsearch",
    "ServiceTags": [
      "TRANSPORT_PORT"
    ],
    "ServicePort": 9300
}]
```

After the change, notice `test` is included in `ServiceTags`.
```
$ curl -s consul:8500/v1/catalog/service/elasticsearch | jq .
[{
    "Node": "mesos-follower-1",
    "ServiceName": "elasticsearch",
    "ServiceTags": [
      "test",
      "CLIENT_PORT"
    ],
    "ServicePort": 9200
  }, {
    "Node": "mesos-follower-1",
    "ServiceName": "elasticsearch",
    "ServiceTags": [
      "test",
      "TRANSPORT_PORT"
    ],
    "ServicePort": 9300
}]
```
