### PR TITLE
Add tags defined per port from discovery info

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -276,4 +276,18 @@ type DiscoveryPort struct {
 	Protocol string `json:"protocol"`
 	Number   int    `json:"number"`
 	Name     string `json:"name"`
+	Labels   struct {
+		Labels []Label `json:"labels"`
+	} `json:"labels"`
+}
+
+// Label returns the label.Value of the key matching the passed in string
+func (p *DiscoveryPort) Label(name string) string {
+	for _, l := range p.Labels.Labels {
+		if l.Key == name {
+			return l.Value
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
Add tags to the service based the `tags` label of the discovery info
of each port. As many other services consume these tags this can be
useful to disable load balancing of some ports or indicate that they
provide a monitoring endpoint.