### PR TITLE
Override Marathon task name by label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM gliderlabs/alpine:3.1
 
 MAINTAINER Chris Aubuchon <Chris.Aubuchon@gmail.com>
+ARG http_proxy=http://proxy.expert.de:8080
+ARG https_proxy=http://proxy.expert.de:8080
 
 COPY . /go/src/github.com/CiscoCloud/mesos-consul
 RUN apk add --update go git mercurial \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ MAINTAINER Chris Aubuchon <Chris.Aubuchon@gmail.com>
 ARG http_proxy=http://proxy.expert.de:8080
 ARG https_proxy=http://proxy.expert.de:8080
 
+ENV http_proxy http://proxy.expert.de:8080
+ENV https_proxy http://proxy.expert.de:8080
+
 COPY . /go/src/github.com/CiscoCloud/mesos-consul
 RUN apk add --update go git mercurial \
 	&& cd /go/src/github.com/CiscoCloud/mesos-consul \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ MAINTAINER Chris Aubuchon <Chris.Aubuchon@gmail.com>
 ARG http_proxy=http://proxy.expert.de:8080
 ARG https_proxy=http://proxy.expert.de:8080
 
-ENV http_proxy http://proxy.expert.de:8080
-ENV https_proxy http://proxy.expert.de:8080
 
 COPY . /go/src/github.com/CiscoCloud/mesos-consul
 RUN apk add --update go git mercurial \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 FROM gliderlabs/alpine:3.1
 
 MAINTAINER Chris Aubuchon <Chris.Aubuchon@gmail.com>
-ARG http_proxy=http://proxy.expert.de:8080
-ARG https_proxy=http://proxy.expert.de:8080
-
 
 COPY . /go/src/github.com/CiscoCloud/mesos-consul
 RUN apk add --update go git mercurial \

--- a/README.md
+++ b/README.md
@@ -161,9 +161,12 @@ This will result in a service `tagging-test` being created in consul with 3 sepa
   }
 ]
 ```
+#### Override Task Name
+
+By adding a label `overrideTaskName` with an arbitrary value, the value is used as the service name during consul registration.
+Tags are preserved.
 
 ## Todo
 
   * Use task labels for metadata
   * Support for multiple port tasks^
-  * Override Marathon Taskname

--- a/README.md
+++ b/README.md
@@ -165,4 +165,5 @@ This will result in a service `tagging-test` being created in consul with 3 sepa
 ## Todo
 
   * Use task labels for metadata
-  * Support for multiple port tasks
+  * Support for multiple port tasks^
+  * Override Marathon Taskname

--- a/README.md
+++ b/README.md
@@ -169,4 +169,4 @@ Tags are preserved.
 ## Todo
 
   * Use task labels for metadata
-  * Support for multiple port tasks^
+  * Support for multiple port tasks

--- a/mesos/register.go
+++ b/mesos/register.go
@@ -103,6 +103,11 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 	var tags []string
 
 	tname := cleanName(t.Name, m.Separator)
+        log.Infof("original TaskName : (%v)", tname)
+	if t.Label("overrideTaskName") != "" {
+		tname = cleanName(t.Label("overrideTaskName"), m.Separator)
+		log.Infof("overrideTaskName to : (%v)", tname)
+	}
 	if !m.TaskPrivilege.Allowed(tname) {
 		// Task not allowed to be registered
 		return

--- a/mesos/register.go
+++ b/mesos/register.go
@@ -103,10 +103,10 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 	var tags []string
 
 	tname := cleanName(t.Name, m.Separator)
-        log.Infof("original TaskName : (%v)", tname)
+        log.Debugf("original TaskName : (%v)", tname)
 	if t.Label("overrideTaskName") != "" {
 		tname = cleanName(t.Label("overrideTaskName"), m.Separator)
-		log.Infof("overrideTaskName to : (%v)", tname)
+		log.Debugf("overrideTaskName to : (%v)", tname)
 	}
 	if !m.TaskPrivilege.Allowed(tname) {
 		// Task not allowed to be registered


### PR DESCRIPTION
By using the label `overrideTaskName` one can specify the name to be registered in consul