### PR TITLE
Included default TCP check in tasks that has not check defined

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -112,6 +112,8 @@ func (c *Consul) Register(service *registry.Service) {
 			Script:   service.Check.Script,
 			HTTP:     service.Check.HTTP,
 			Interval: service.Check.Interval,
+			TCP:      service.Check.TCP,
+			Timeout:  service.Check.Timeout,
 		},
 	}
 

--- a/mesos/state.go
+++ b/mesos/state.go
@@ -15,30 +15,55 @@ type CheckVar struct {
 
 var globalCV *CheckVar
 
+const defaultInterval = "2s"
+const defaultTimeout = "60s"
+
 // Task Methods
 
 // GetCheck()
 //   Build a Check structure from the Task labels
 //
 func GetCheck(t *state.Task, cv *CheckVar) *registry.Check {
+	matched := false
 	c := registry.DefaultCheck()
-
 	for _, l := range t.Labels {
 		k := strings.ToLower(l.Key)
 
 		switch k {
 		case "check_http":
 			c.HTTP = interpolate(cv, l.Value)
+			matched = true
 		case "check_script":
 			c.Script = interpolate(cv, l.Value)
+			matched = true
 		case "check_ttl":
 			c.TTL = interpolate(cv, l.Value)
+			matched = true
 		case "check_interval":
 			c.Interval = l.Value
+			matched = true
 		}
 	}
 
+	if !matched {
+		c.TCP = interpolate(cv, hostPortToString(cv))
+		c.Interval = defaultInterval
+		c.Timeout = defaultTimeout
+
+	}
+
 	return c
+}
+
+// Returns a CheckVar struct in "IP:PORT" format
+//
+func hostPortToString(cv *CheckVar) string {
+	strResult := ""
+	if cv.Host != "" && cv.Port != "" {
+		strResult = strings.Join([]string{cv.Host, ":", cv.Port}, "")
+	}
+
+	return strResult
 }
 
 // Replace {variables} with values

--- a/registry/structs.go
+++ b/registry/structs.go
@@ -5,6 +5,8 @@ type Check struct {
 	TTL      string
 	HTTP     string
 	Interval string
+	TCP      string
+	Timeout  string
 }
 
 type Service struct {
@@ -34,5 +36,7 @@ func DefaultCheck() *Check {
 		Script:   "",
 		HTTP:     "",
 		Interval: "",
+		TCP:      "",
+		Timeout:  "",
 	}
 }


### PR DESCRIPTION
Hi, while running some apps in marathon that exposes a port it wasn't monitoring the health check (TCP for example). Check out if this is interesting for you, as it is for me.

Regards.