### PR TITLE
Only register a portless service when already registered

### DIFF
--- a/mesos/register.go
+++ b/mesos/register.go
@@ -102,6 +102,8 @@ func (m *Mesos) registerHost(s *registry.Service) {
 func (m *Mesos) registerTask(t *state.Task, agent string) {
 	var tags []string
 
+	registered := false
+
 	tname := cleanName(t.Name, m.Separator)
         log.Debugf("original TaskName : (%v)", tname)
 	if t.Label("overrideTaskName") != "" {
@@ -145,6 +147,7 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 				}),
 				Agent: toIP(agent),
 			})
+			registered = true
 		}
 	}
 
@@ -162,8 +165,11 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 				}),
 				Agent: toIP(agent),
 			})
+			registered = true
 		}
-	} else {
+	} 
+
+	if !registered {
 		m.Registry.Register(&registry.Service{
 			ID:      fmt.Sprintf("mesos-consul:%s-%s:address", agent, tname, address),
 			Name:    tname,


### PR DESCRIPTION
In the case when a service is registered via the DiscoveryInfo a second
service would be registered with no port information. Only register a
portless service when a service is not registered