### PR TITLE
make consul service id prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You can add options to authenticate via basic http or Consul token.
 |         Option        | Description |
 |-----------------------|-------------|
 | `version`             | Print mesos-consul version
+| `log-level` | Set the Logging level to one of DEBUG, INFO, WARN, ERROR. (default WARN)
 | `refresh`             | Time between refreshes of Mesos tasks
 | `mesos-ip-order`             | Comma separated list to control the order in which github.com/CiscoCloud/mesos-consul searches or the task IP address. Valid options are 'netinfo', 'mesos', 'docker' and 'host' (default netinfo,mesos,host)
 | `healthcheck`             | Enables a http endpoint for health checks. When this flag is enabled, serves health status on 127.0.0.1:24476
@@ -106,6 +107,7 @@ You can add options to authenticate via basic http or Consul token.
 | `blacklist`         | Does not register services matching the provided regex. Can be specified multitple time
 | `service-name=<name>`      | Service name of the Mesos hosts
 | `service-tags=<tag>,...` | Comma delimited list of tags to register the Mesos hosts. Mesos hosts will be registered as (leader|master|follower).<tag>.<service>.service.consul
+| `service-id-prefix=<prefix>` | Prefix to use for consul service ids registered by mesos-consul. (default: mesos-consul)
 | `task-tag=<pattern:tag>` | Tag tasks matching pattern with given tag. Can be specified multitple times
 | `zk`\*                 | Location of the Mesos path in Zookeeper. The default value is zk://127.0.0.1:2181/mesos
 | `group-separator`      | Choose the group separator. Will replace _ in task names (default is empty)

--- a/config/config.go
+++ b/config/config.go
@@ -20,8 +20,9 @@ type Config struct {
 	Separator       string
 
 	// Mesos service name and tags
-	ServiceName string
-	ServiceTags string
+	ServiceName     string
+	ServiceTags     string
+	ServiceIdPrefix string
 }
 
 func DefaultConfig() *Config {
@@ -40,5 +41,6 @@ func DefaultConfig() *Config {
 		Separator:       "",
 		ServiceName:     "mesos",
 		ServiceTags:     "",
+		ServiceIdPrefix: "mesos-consul",
 	}
 }

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func parseFlags(args []string) (*config.Config, error) {
 	}), "task-tag", "")
 	flags.StringVar(&c.ServiceName, "service-name", "mesos", "")
 	flags.StringVar(&c.ServiceTags, "service-tags", "", "")
+	flags.StringVar(&c.ServiceIdPrefix, "service-id-prefix", "mesos-consul", "")
 
 	consul.AddCmdFlags(flags)
 

--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -33,17 +33,18 @@ type Mesos struct {
 	started   sync.Once
 	startChan chan struct{}
 
-	IpOrder        []string
-	taskTag        map[string][]string
+	IpOrder []string
+	taskTag map[string][]string
 
 	// Whitelist/Blacklist privileges
 	TaskPrivilege *Privilege
-	FwPrivilege *Privilege
+	FwPrivilege   *Privilege
 
 	Separator string
 
-	ServiceName string
-	ServiceTags []string
+	ServiceName     string
+	ServiceTags     []string
+	ServiceIdPrefix string
 }
 
 func New(c *config.Config) *Mesos {
@@ -86,6 +87,8 @@ func New(c *config.Config) *Mesos {
 	if c.ServiceTags != "" {
 		m.ServiceTags = strings.Split(c.ServiceTags, ",")
 	}
+
+	m.ServiceIdPrefix = c.ServiceIdPrefix
 
 	return m
 }

--- a/registry/structs.go
+++ b/registry/structs.go
@@ -20,7 +20,7 @@ type Service struct {
 type Registry interface {
 	CacheCreate() bool
 	CacheDelete(string)
-	CacheLoad(string) error
+	CacheLoad(string, string) error
 	CacheLookup(string) *Service
 	CacheMark(string)
 


### PR DESCRIPTION
This PR makes the consul service id prefix that mesos-consul uses configurable. Default values leave the original prefix (mesos-consul) unchanged.

Without this option, using mesos-consul in different mesos clusters against the same consul cluster will result in conflicts where mesos-consul from each mesos cluster repeatedly overwrite each other's services.