### PR TITLE
Add Consul timeout option

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -16,6 +16,7 @@ type consulConfig struct {
 	sslCert                string
 	sslCaCert              string
 	token                  string
+	timeout                int
 	heartbeatsBeforeRemove int
 }
 
@@ -30,6 +31,7 @@ func AddCmdFlags(f *flag.FlagSet) {
 	f.StringVar(&config.sslCert, "consul-ssl-cert", "", "")
 	f.StringVar(&config.sslCaCert, "consul-ssl-cacert", "", "")
 	f.StringVar(&config.token, "consul-token", "", "")
+	f.IntVar(&config.timeout, "consul-timeout", 0, "")
 	f.IntVar(&config.heartbeatsBeforeRemove, "heartbeats-before-remove", 1, "")
 }
 
@@ -56,6 +58,8 @@ Consul Options:
 				(default: not set)
   --consul-token		The Consul ACL token
 				(default: not set)
+  --consul-timeout		Set a timeout (in seconds) on requests to Consul
+				(default: 0)
   --heartbeats-before-remove	Number of times that registration needs to fail
 				before removing task from Consul
 				(default: 1)

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/CiscoCloud/mesos-consul/registry"
 
@@ -53,6 +54,9 @@ func (c *Consul) newAgent(address string) *consulapi.Client {
 
 	config.Address = fmt.Sprintf("%s:%s", address, c.config.port)
 	log.Debugf("consul address: %s", config.Address)
+
+	config.HttpClient.Timeout = time.Duration(c.config.timeout) * time.Second
+	log.Debugf("consul timeout: %d", config.HttpClient.Timeout)
 
 	if c.config.token != "" {
 		log.Debugf("setting token to %s", c.config.token)


### PR DESCRIPTION
This small patch adds the possibility of configuring the HTTP client timeout option (there are edge cases where the Consul agent may be malfunctioning and not responding in a timely manner).