### PR TITLE
Remove default health-check ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To build it:
 | `refresh`             | Time between refreshes of Mesos tasks
 | `mesos-ip-order`             | Comma separated list to control the order in which github.com/CiscoCloud/mesos-consul searches or the task IP address. Valid options are 'netinfo', 'mesos', 'docker' and 'host' (default netinfo,mesos,host)
 | `healthcheck`             | Enables a http endpoint for health checks. When this flag is enabled, serves health status on 127.0.0.1:24476
-| `healthcheck-ip`             | Health check service interface ip (default 127.0.0.1)
+| `healthcheck-ip`             | Health check service interface ip
 | `healthcheck-port`             | Health check service port. (default 24476)
 | `consul-auth`       | The basic authentication username (and optional password), separated by a colon.
 | `consul-ssl`        | Use HTTPS while talking to the registry.

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func parseFlags(args []string) (*config.Config, error) {
 	flags.StringVar(&c.Separator, "group-separator", "", "")
 	flags.StringVar(&c.MesosIpOrder, "mesos-ip-order", "netinfo,mesos,host", "")
 	flags.BoolVar(&c.Healthcheck, "healthcheck", false, "")
-	flags.StringVar(&c.HealthcheckIp, "healthcheck-ip", "127.0.0.1", "")
+	flags.StringVar(&c.HealthcheckIp, "healthcheck-ip", "", "")
 	flags.StringVar(&c.HealthcheckPort, "healthcheck-port", "24476", "")
 	flags.Var((funcVar)(func(s string) error {
 		c.TaskWhiteList = append(c.TaskWhiteList, s)
@@ -136,7 +136,7 @@ Options:
   --group-separator=<separator> Choose the group separator. Will replace _ in task names (default is empty)
   --healthcheck 		Enables a http endpoint for health checks. When this
 				flag is enabled, serves a service health status on 127.0.0.1:24476 (default not enabled)
-  --healthcheck-ip=<ip> 	Health check interface ip (default 127.0.0.1)
+  --healthcheck-ip=<ip> 	Health check interface ip
   --healthcheck-port=<port>	Health check service port (default 24476)
   --mesos-ip-order		Comma separated list to control the order in
 				which github.com/CiscoCloud/mesos-consul searches for the task IP


### PR DESCRIPTION
@ChrisAubuchon @atongen @erSitzt 

This makes health check server to listen on all network interfaces. I had problem since default ip is localhost or lo interface running mesos health checks is not possible since by default it listens on localhost and there is no change to now docker IP in advance to set it via flag.

Note: removal does not change previous behavior but rather improves it. 
