### PR TITLE
Add possibility to override task-name per port

### DIFF
--- a/mesos/register.go
+++ b/mesos/register.go
@@ -141,10 +141,14 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 		} else {
 			porttags = []string{}
 		}
+		tnamePort := tname
+		if discoveryPort.Label("overrideTaskName") != "" {
+			tnamePort = discoveryPort.Label("overrideTaskName")
+		}
 		if discoveryPort.Name != "" {
 			m.Registry.Register(&registry.Service{
-				ID:      fmt.Sprintf("%s:%s:%s:%s:%d", m.ServiceIdPrefix, agent, tname, address, discoveryPort.Number),
-				Name:    tname,
+				ID:      fmt.Sprintf("%s:%s:%s:%s:%d", m.ServiceIdPrefix, agent, tnamePort, address, discoveryPort.Number),
+				Name:    tnamePort,
 				Port:    toPort(servicePort),
 				Address: address,
 				Tags:    append(append(tags, serviceName), porttags...),


### PR DESCRIPTION
If you have the a UI and an API endpoint serviced from the same
container but on different ports you can grouped them as different
services.